### PR TITLE
test(frankenphp): Add tests for `ignore_user_abort` behavior and ensure it's called correctly.

### DIFF
--- a/src/FrankenPHP.php
+++ b/src/FrankenPHP.php
@@ -81,9 +81,7 @@ final class FrankenPHP
     public function run(): int
     {
         // prevent worker script termination when a client connection is interrupted
-        // @codeCoverageIgnoreStart
         ignore_user_abort(true);
-        // @codeCoverageIgnoreEnd
 
         $app = $this->app;
         $emitter = $this->emitter;

--- a/tests/support/MockerExtension.php
+++ b/tests/support/MockerExtension.php
@@ -59,6 +59,11 @@ final class MockerExtension implements Extension
                 'name' => 'frankenphp_handle_request',
                 'function' => static fn(Closure $handler): bool => HTTPFunctions::frankenphp_handle_request($handler),
             ],
+            [
+                'namespace' => 'yii2\extensions\frankenphp',
+                'name' => 'ignore_user_abort',
+                'function' => static fn(bool|null $value = null): int => HTTPFunctions::ignore_user_abort($value),
+            ],
         ];
 
         $mocker = new Mocker();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new tests to verify the behavior and settings of user abort handling during server execution.
* **Chores**
  * Enhanced internal test utilities to better simulate and track user abort handling for improved test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->