### PR TITLE
fix: Update `infection/infection` version constraint to allow `0.31`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "httpsoft/http-message": "^1.1",
-        "infection/infection": "^0.27|^0.30",
+        "infection/infection": "^0.27|^0.31",
         "maglnet/composer-require-checker": "^4.1",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-strict-rules": "^2.0.3",


### PR DESCRIPTION
# Pull Request

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency for mutation testing to accept the latest 0.31.x releases, removing the 0.30.x path to improve tooling compatibility and maintenance.
  * No user-facing functionality or public APIs were changed.
  * Build and CI environments may experience minor tooling updates; application runtime behavior remains unaffected.
  * Ensures continued access to fixes and improvements in the supported dependency version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->