### PR TITLE
fix(docs): Correct closing brace in `installation.md` for PHP server configuration.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -89,7 +89,7 @@ localhost {
     php_server {
         try_files {path} index.php
     }
-
+}
 ```
 
 ### Install FrankenPHP binary


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
